### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) server for Excalidraw, providing API functionality for operating on Excalidraw drawings.
 
+<a href="https://glama.ai/mcp/servers/@i-tozer/excalidraw-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@i-tozer/excalidraw-mcp/badge" alt="Excalidraw Server MCP server" />
+</a>
+
 ## Features
 
 - Create, read, update, and delete Excalidraw drawings
@@ -80,4 +84,4 @@ npm run dev
 
 ## License
 
-MIT 
+MIT


### PR DESCRIPTION
This PR adds a badge for the [Excalidraw MCP Server](https://glama.ai/mcp/servers/@i-tozer/excalidraw-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@i-tozer/excalidraw-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@i-tozer/excalidraw-mcp/badge" alt="Excalidraw Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.